### PR TITLE
API 4.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - uses: gradle/wrapper-validation-action@v1
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
@@ -12,5 +13,7 @@ jobs:
         java-version: 11
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+    - name: init submodule
+      run: git submodule init && git submodule update
     - name: Build with Gradle
       run: ./gradlew shadowJar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,5 @@ jobs:
         java-version: 11
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: init submodule
-      run: git submodule init && git submodule update
     - name: Build with Gradle
       run: ./gradlew shadowJar --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,4 +16,4 @@ jobs:
     - name: init submodule
       run: git submodule init && git submodule update
     - name: Build with Gradle
-      run: ./gradlew shadowJar
+      run: ./gradlew shadowJar --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
         distribution: temurin
-        java-version: 8
+        java-version: 11
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew shadowJar -Prelease=${{  github.ref_name }}
+        run: ./gradlew shadowJar -Prelease=${{  github.ref_name }} --no-daemon
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "mclogs-java"]
-	path = mclogs-java
-	url = http://github.com/aternosorg/mclogs-java.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mclogs-java"]
+	path = mclogs-java
+	url = http://github.com/aternosorg/mclogs-java.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fix modrinth publishing
+- Makes use of API version 4.0.0, allowing for marginal performance increases as API calls are now Async

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,11 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id "com.modrinth.minotaur" version "2.8.1"
     id "xyz.jpenilla.run-paper" version "2.1.0"
-    id "maven-publish"
 }
 
 version = project.hasProperty('release') ? project.getProperty('release') : 'dev'
+sourceCompatibility = 11
+targetCompatibility = 11
 
 repositories {
     mavenCentral()
@@ -19,7 +20,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.spigotmc:spigot-api:1.19.2-R0.1-SNAPSHOT'
-    implementation project(path: ":mclogs-java", configuration: 'default')
+    implementation 'gs.mclo:api:4.0.1'
     implementation "net.kyori:adventure-api:4.13.0"
     implementation "net.kyori:adventure-platform-bukkit:4.2.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'java'
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
-    id "com.modrinth.minotaur" version "2.+"
-    id "xyz.jpenilla.run-paper" version "2.0.1"
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id "com.modrinth.minotaur" version "2.8.1"
+    id "xyz.jpenilla.run-paper" version "2.1.0"
+    id "maven-publish"
 }
 
 version = project.hasProperty('release') ? project.getProperty('release') : 'dev'
@@ -18,7 +19,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.spigotmc:spigot-api:1.19.2-R0.1-SNAPSHOT'
-    implementation 'gs.mclo:api:3.0.1'
+    implementation project(path: ":mclogs-java", configuration: 'default')
     implementation "net.kyori:adventure-api:4.13.0"
     implementation "net.kyori:adventure-platform-bukkit:4.2.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ shadowJar {
 
 tasks {
     runServer {
-        minecraftVersion("1.19.3")
+        minecraftVersion("1.20.1")
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,3 @@
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-    }
-}
-
 rootProject.name = 'mclogs-bukkit'
+include ':mclogs-java'
+project(':mclogs-java').projectDir = new File('./mclogs-java/')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,1 @@
 rootProject.name = 'mclogs-bukkit'
-include ':mclogs-java'
-project(':mclogs-java').projectDir = new File('./mclogs-java/')


### PR DESCRIPTION
- Updates gradle wrapper to 8.1.1, as well as gradle plugins
- Updates workflow versions, uses gradle validation 
- Uses proper submodule setup 
- Uses java 11 
- Uses API version 4.0.0

Note: Releasing will have to be altered with the shadow update, likely just to fix naming conventions. This will also require updating the release workflow